### PR TITLE
feat: 캔버스 녹화 기능 개선

### DIFF
--- a/src/CanvasSection.tsx
+++ b/src/CanvasSection.tsx
@@ -48,8 +48,12 @@ const CanvasSection = () => {
     a.download = 'canvas-recording.webm'
     a.click()
     URL.revokeObjectURL(url)
+    setRecordedChunks([])
   }
 
+  setRecordedChunks([])
+  setMediaRecorder(mediaRecorder)
+  setIsRecording(true)
   mediaRecorder.start()
 
   // 렌더링 트리거 (캔버스가 멈춰 있으면 스트림이 생성되지 않음)
@@ -59,15 +63,12 @@ const CanvasSection = () => {
     requestAnimationFrame(animate)
   }
   animate()
-
-  // 5초 후 자동 종료
-  setTimeout(() => {
-    mediaRecorder.stop()
-  }, 5000)
+  
 }
 
 const stopRecording = () => {
   mediaRecorder?.stop()
+  setIsRecording(false)
 }
 
   const [pdfDoc, setPdfDoc] = useState<any>(null)


### PR DESCRIPTION
📌 캔버스 녹화 기능
- `MediaRecorder` API를 활용해 캔버스 영역 녹화 기능 구현
- 사용자가 `🎥 녹화 시작` 버튼을 클릭하면 `canvas.captureStream()`을 통해 `.webm` 포맷으로 녹화 시작
- 기존 4초 자동 녹화에서 개선되어, `⏹ 녹화 중지` 버튼을 눌러야 종료되도록 변경
- 녹화 종료 시 `.webm` 파일 자동 다운로드 처리
- Fabric.js의 `renderAll()`을 `requestAnimationFrame`으로 지속 호출하여 스트림 생성 유지

✅테스트 방법
1. 캔버스에 자유롭게 그린다.
2. 🎥 버튼 클릭 후 몇 초간 작업한다.
3. ⏹ 중지 버튼 클릭 → `.webm` 파일이 자동 다운로드되는지 확인